### PR TITLE
9 temporarily disable warnings as errors during ci

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ on:
   push:	
     branches:	
       - develop
+      - 9-temporarily-disable-warnings-as-errors-during-ci
 
 jobs:
   deploy:
@@ -20,6 +21,8 @@ jobs:
       run: |
         yarn install
         yarn build
+      env:
+        CI: false
 
     # Deploy to `hosting` branch
     - name: Deploy to hosting branch

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,7 +3,6 @@ on:
   push:	
     branches:	
       - develop
-      - 9-temporarily-disable-warnings-as-errors-during-ci
 
 jobs:
   deploy:


### PR DESCRIPTION
Disabled the `CI` environment variable for the `build` step of the workflow, so that warnings are not treated as errors. This is a temporary workaround until the underlying source can be properly fixed.